### PR TITLE
Changes for use in QUIC

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -11,8 +11,10 @@ import (
 	"github.com/gogo/protobuf/proto"
 	ic "github.com/libp2p/go-libp2p-crypto"
 	pb "github.com/libp2p/go-libp2p-crypto/pb"
-	peer "github.com/libp2p/go-libp2p-peer"
+	"github.com/libp2p/go-libp2p-peer"
 )
+
+const PEER_HOSTNAME = "tls.libp2p"
 
 // Identity is used to secure connections
 type Identity struct {
@@ -55,6 +57,9 @@ func (i *Identity) ConfigForPeer(remote peer.ID) *tls.Config {
 		}
 		return nil
 	}
+
+	conf.ServerName = PEER_HOSTNAME
+
 	return conf
 }
 
@@ -102,6 +107,7 @@ func keyToCertificate(sk ic.PrivKey) (interface{}, *x509.Certificate, error) {
 		return nil, nil, err
 	}
 	tmpl := &x509.Certificate{
+		DNSNames:     []string{PEER_HOSTNAME},
 		SerialNumber: sn,
 		NotBefore:    time.Now().Add(-24 * time.Hour),
 		NotAfter:     time.Now().Add(certValidityPeriod),

--- a/transport.go
+++ b/transport.go
@@ -48,7 +48,8 @@ func (t *Transport) SecureInbound(ctx context.Context, insecure net.Conn) (cs.Co
 
 // SecureOutbound runs the TLS handshake as a client.
 func (t *Transport) SecureOutbound(ctx context.Context, insecure net.Conn, p peer.ID) (cs.Conn, error) {
-	cl := tls.Client(insecure, t.identity.ConfigForPeer(p))
+	config, _ := t.identity.ConfigForPeer(p)
+	cl := tls.Client(insecure, config)
 	return t.handshake(ctx, insecure, cl)
 }
 


### PR DESCRIPTION
These two changes are required so that go-libp2p-quic-transport can use this package. Both changes are agnostic of quic, and should be required of basically any transport which will rely on this package in the future.

Use standard hostname for certs is required since otherwise mint will attempt to infer the hostname of the connected server. This is incorrect, so we choose a public hostname that all libp2p tls transports will share. This is the same behavior as quic-transport currently exhibits.

Return pubkeys which connect to us to caller is required to pass back the public key of the remote peer so an implementing connection can provide it to satisfy the ConnSecurity interface.

This is the majority of the work to allow this package to be used by QUIC. See #4 