### PR TITLE
improve peer verification

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 
 	cs "github.com/libp2p/go-conn-security"
-	ic "github.com/libp2p/go-libp2p-crypto"
+	ci "github.com/libp2p/go-libp2p-crypto"
 	peer "github.com/libp2p/go-libp2p-peer"
 )
 
@@ -12,10 +12,10 @@ type conn struct {
 	*tls.Conn
 
 	localPeer peer.ID
-	privKey   ic.PrivKey
+	privKey   ci.PrivKey
 
 	remotePeer   peer.ID
-	remotePubKey ic.PubKey
+	remotePubKey ci.PubKey
 }
 
 var _ cs.Conn = &conn{}
@@ -24,7 +24,7 @@ func (c *conn) LocalPeer() peer.ID {
 	return c.localPeer
 }
 
-func (c *conn) LocalPrivateKey() ic.PrivKey {
+func (c *conn) LocalPrivateKey() ci.PrivKey {
 	return c.privKey
 }
 
@@ -32,6 +32,6 @@ func (c *conn) RemotePeer() peer.ID {
 	return c.remotePeer
 }
 
-func (c *conn) RemotePublicKey() ic.PubKey {
+func (c *conn) RemotePublicKey() ci.PubKey {
 	return c.remotePubKey
 }

--- a/crypto.go
+++ b/crypto.go
@@ -69,7 +69,10 @@ func NewIdentity(
 
 // ConfigForPeer creates a new tls.Config that verifies the peers certificate chain.
 // It should be used to create a new tls.Config before dialing.
-func (i *Identity) ConfigForPeer(remote peer.ID) *tls.Config {
+func (i *Identity) ConfigForPeer(
+	remote peer.ID,
+	verifiedPeerCallback func(ic.PubKey),
+) *tls.Config {
 	// We need to check the peer ID in the VerifyPeerCertificate callback.
 	// The tls.Config it is also used for listening, and we might also have concurrent dials.
 	// Clone it so we can check for the specific peer ID we're dialing here.
@@ -92,14 +95,10 @@ func (i *Identity) ConfigForPeer(remote peer.ID) *tls.Config {
 		if !remote.MatchesPublicKey(pubKey) {
 			return errors.New("peer IDs don't match")
 		}
+		verifiedPeerCallback(pubKey)
 		return nil
 	}
 	return conf
-}
-
-// KeyFromChain takes a chain of x509.Certificates and returns the peer's public key.
-func KeyFromChain(chain []*x509.Certificate) (ic.PubKey, error) {
-	return getRemotePubKey(chain)
 }
 
 // getRemotePubKey derives the remote's public key from the certificate chain.

--- a/transport.go
+++ b/transport.go
@@ -9,7 +9,6 @@ import (
 
 	cs "github.com/libp2p/go-conn-security"
 	ci "github.com/libp2p/go-libp2p-crypto"
-	ic "github.com/libp2p/go-libp2p-crypto"
 	peer "github.com/libp2p/go-libp2p-peer"
 )
 
@@ -101,7 +100,7 @@ func (t *Transport) handshake(
 	}
 
 	// Should be ready by this point, don't block.
-	var remotePubKey ic.PubKey
+	var remotePubKey ci.PubKey
 	select {
 	case remotePubKey = <-keyCh:
 	default:
@@ -118,7 +117,7 @@ func (t *Transport) handshake(
 	return conn, nil
 }
 
-func (t *Transport) setupConn(tlsConn *tls.Conn, remotePubKey ic.PubKey) (cs.Conn, error) {
+func (t *Transport) setupConn(tlsConn *tls.Conn, remotePubKey ci.PubKey) (cs.Conn, error) {
 	if remotePubKey == nil {
 		return nil, errors.New("go-libp2p-tls BUG: expected remote pub key to be set")
 	}

--- a/transport.go
+++ b/transport.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"net"
 	"os"
-	"sync"
 
 	cs "github.com/libp2p/go-conn-security"
 	ci "github.com/libp2p/go-libp2p-crypto"
@@ -29,9 +28,6 @@ type Transport struct {
 
 	localPeer peer.ID
 	privKey   ci.PrivKey
-
-	activeMutex sync.Mutex
-	active      map[net.Conn]ic.PubKey
 }
 
 // New creates a TLS encrypted transport
@@ -43,14 +39,9 @@ func New(key ci.PrivKey) (*Transport, error) {
 	t := &Transport{
 		localPeer: id,
 		privKey:   key,
-		active:    make(map[net.Conn]ic.PubKey),
 	}
 
-	identity, err := NewIdentity(key, func(conn net.Conn, pubKey ic.PubKey) {
-		t.activeMutex.Lock()
-		t.active[conn] = pubKey
-		t.activeMutex.Unlock()
-	})
+	identity, err := NewIdentity(key)
 	if err != nil {
 		return nil, err
 	}
@@ -62,15 +53,8 @@ var _ cs.Transport = &Transport{}
 
 // SecureInbound runs the TLS handshake as a server.
 func (t *Transport) SecureInbound(ctx context.Context, insecure net.Conn) (cs.Conn, error) {
-	defer func() {
-		t.activeMutex.Lock()
-		// only contains this connection if we successfully derived the client's key
-		delete(t.active, insecure)
-		t.activeMutex.Unlock()
-	}()
-
-	serv := tls.Server(insecure, t.identity.Config)
-	return t.handshake(ctx, insecure, serv)
+	config, keyCh := t.identity.ConfigForAny()
+	return t.handshake(ctx, tls.Server(insecure, config), keyCh)
 }
 
 // SecureOutbound runs the TLS handshake as a client.
@@ -81,19 +65,14 @@ func (t *Transport) SecureInbound(ctx context.Context, insecure net.Conn) (cs.Co
 // If the handshake fails, the server will close the connection. The client will
 // notice this after 1 RTT when calling Read.
 func (t *Transport) SecureOutbound(ctx context.Context, insecure net.Conn, p peer.ID) (cs.Conn, error) {
-	verifiedCallback := func(pubKey ic.PubKey) {
-		t.activeMutex.Lock()
-		t.active[insecure] = pubKey
-		t.activeMutex.Unlock()
-	}
-	cl := tls.Client(insecure, t.identity.ConfigForPeer(p, verifiedCallback))
-	return t.handshake(ctx, insecure, cl)
+	config, keyCh := t.identity.ConfigForPeer(p)
+	return t.handshake(ctx, tls.Client(insecure, config), keyCh)
 }
 
 func (t *Transport) handshake(
 	ctx context.Context,
-	insecure net.Conn,
 	tlsConn *tls.Conn,
+	keyCh <-chan ci.PubKey,
 ) (cs.Conn, error) {
 	// There's no way to pass a context to tls.Conn.Handshake().
 	// See https://github.com/golang/go/issues/18482.
@@ -120,7 +99,15 @@ func (t *Transport) handshake(
 		}
 		return nil, err
 	}
-	conn, err := t.setupConn(insecure, tlsConn)
+
+	// Should be ready by this point, don't block.
+	var remotePubKey ic.PubKey
+	select {
+	case remotePubKey = <-keyCh:
+	default:
+	}
+
+	conn, err := t.setupConn(tlsConn, remotePubKey)
 	if err != nil {
 		// if the context was canceled, return the context error
 		if ctxErr := ctx.Err(); ctxErr != nil {
@@ -131,11 +118,7 @@ func (t *Transport) handshake(
 	return conn, nil
 }
 
-func (t *Transport) setupConn(insecure net.Conn, tlsConn *tls.Conn) (cs.Conn, error) {
-	t.activeMutex.Lock()
-	remotePubKey := t.active[insecure]
-	t.activeMutex.Unlock()
-
+func (t *Transport) setupConn(tlsConn *tls.Conn, remotePubKey ic.PubKey) (cs.Conn, error) {
 	if remotePubKey == nil {
 		return nil, errors.New("go-libp2p-tls BUG: expected remote pub key to be set")
 	}

--- a/transport_test.go
+++ b/transport_test.go
@@ -180,15 +180,15 @@ var _ = Describe("Transport", func() {
 
 	Context("invalid certificates", func() {
 		invalidateCertChain := func(identity *Identity) {
-			switch identity.Config.Certificates[0].PrivateKey.(type) {
+			switch identity.config.Certificates[0].PrivateKey.(type) {
 			case *rsa.PrivateKey:
 				key, err := rsa.GenerateKey(rand.Reader, 1024)
 				Expect(err).ToNot(HaveOccurred())
-				identity.Config.Certificates[0].PrivateKey = key
+				identity.config.Certificates[0].PrivateKey = key
 			case *ecdsa.PrivateKey:
 				key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 				Expect(err).ToNot(HaveOccurred())
-				identity.Config.Certificates[0].PrivateKey = key
+				identity.config.Certificates[0].PrivateKey = key
 			default:
 				Fail("unexpected private key type")
 			}
@@ -206,7 +206,7 @@ var _ = Describe("Transport", func() {
 			Expect(err).ToNot(HaveOccurred())
 			cert2DER, err := x509.CreateCertificate(rand.Reader, tmpl, cert1, key2.Public(), key2)
 			Expect(err).ToNot(HaveOccurred())
-			identity.Config.Certificates = []tls.Certificate{{
+			identity.config.Certificates = []tls.Certificate{{
 				Certificate: [][]byte{cert2DER, cert1DER},
 				PrivateKey:  key2,
 			}}
@@ -222,7 +222,7 @@ var _ = Describe("Transport", func() {
 			Expect(err).ToNot(HaveOccurred())
 			cert, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, key.Public(), key)
 			Expect(err).ToNot(HaveOccurred())
-			identity.Config.Certificates = []tls.Certificate{{
+			identity.config.Certificates = []tls.Certificate{{
 				Certificate: [][]byte{cert},
 				PrivateKey:  key,
 			}}

--- a/transport_test.go
+++ b/transport_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/onsi/gomega/gbytes"
 
 	cs "github.com/libp2p/go-conn-security"
-	ic "github.com/libp2p/go-libp2p-crypto"
+	ci "github.com/libp2p/go-libp2p-crypto"
 	peer "github.com/libp2p/go-libp2p-peer"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -31,21 +31,21 @@ type transform struct {
 
 var _ = Describe("Transport", func() {
 	var (
-		serverKey, clientKey ic.PrivKey
+		serverKey, clientKey ci.PrivKey
 		serverID, clientID   peer.ID
 	)
 
-	createPeer := func() (peer.ID, ic.PrivKey) {
-		var priv ic.PrivKey
+	createPeer := func() (peer.ID, ci.PrivKey) {
+		var priv ci.PrivKey
 		if mrand.Int()%2 == 0 {
 			fmt.Fprintf(GinkgoWriter, " using an ECDSA key: ")
 			var err error
-			priv, _, err = ic.GenerateECDSAKeyPair(rand.Reader)
+			priv, _, err = ci.GenerateECDSAKeyPair(rand.Reader)
 			Expect(err).ToNot(HaveOccurred())
 		} else {
 			fmt.Fprintf(GinkgoWriter, " using an RSA key: ")
 			var err error
-			priv, _, err = ic.GenerateRSAKeyPair(1024, rand.Reader)
+			priv, _, err = ci.GenerateRSAKeyPair(1024, rand.Reader)
 			Expect(err).ToNot(HaveOccurred())
 		}
 		id, err := peer.IDFromPrivateKey(priv)


### PR DESCRIPTION
Fixes #15. Fixes #16.

This PR fixes two issues by
* always verifying the peer's certificate chain and deriving the libp2p public key in the `tls.Config.VerifyPeerCertificate` callback
* saving the derived libp2p public key along the `net.Conn`. This is necessary since in the `VerifyPeerCertificate` callback the server has no idea which connection it is currently verifying.

Note that this PR will make it harder to reuse the code with QUIC, since in QUIC, there's no such thing as a (unique) `net.Conn` (as a client, you could reuse the same UDP connection to run multiple dials, and a server only listens on a single `net.Conn`). I suggest taking one step at a time and dealing with these issues later.