### PR TITLE
set an ALPN value in the tls.Config

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -21,6 +21,7 @@ import (
 
 const certValidityPeriod = 100 * 365 * 24 * time.Hour // ~100 years
 const certificatePrefix = "libp2p-tls-handshake:"
+const alpn string = "libp2p"
 
 var extensionID = getPrefixedExtensionID([]int{1, 1})
 
@@ -50,6 +51,7 @@ func NewIdentity(privKey ic.PrivKey) (*Identity, error) {
 			VerifyPeerCertificate: func(_ [][]byte, _ [][]*x509.Certificate) error {
 				panic("tls config not specialized for peer")
 			},
+			NextProtos:             []string{alpn},
 			SessionTicketsDisabled: true,
 		},
 	}, nil


### PR DESCRIPTION
Fixes #10.

This sets the application protocol (ALPN, see [RFC 7301](https://tools.ietf.org/html/rfc7301)) to "libp2p". For TCP, use of ALPN is optional, but for QUIC, ALPN is mandatory, and the handshake fails if an endpoint doesn't send the ALPN extension, or if the two peers can't agree on a mutually supported application.

Since the the client sends this extension in the clear (it's part of the ClientHello message), this is one of the many ways that libp2p traffic sticks out. As part of our effort to make our traffic indistinguishable from normal web traffic, we might want to change this to the application name used by HTTP/2 or HTTP/3 at some point in the future, and use an upgrade mechanism like [MASQUE](https://tools.ietf.org/html/draft-schinazi-masque-01).