### PR TITLE
fix: don't fail the handshake when the libp2p extension is critical

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -24,6 +24,7 @@ const certificatePrefix = "libp2p-tls-handshake:"
 const alpn string = "libp2p"
 
 var extensionID = getPrefixedExtensionID([]int{1, 1})
+var extensionCritical bool // so we can mark the extension critical in tests
 
 type signedKey struct {
 	PubKey    []byte
@@ -113,12 +114,6 @@ func PubKeyFromCertChain(chain []*x509.Certificate) (ic.PubKey, error) {
 	cert := chain[0]
 	pool := x509.NewCertPool()
 	pool.AddCert(cert)
-	if _, err := cert.Verify(x509.VerifyOptions{Roots: pool}); err != nil {
-		// If we return an x509 error here, it will be sent on the wire.
-		// Wrap the error to avoid that.
-		return nil, fmt.Errorf("certificate verification failed: %s", err)
-	}
-
 	var found bool
 	var keyExt pkix.Extension
 	// find the libp2p key extension, skipping all unknown extensions
@@ -126,12 +121,25 @@ func PubKeyFromCertChain(chain []*x509.Certificate) (ic.PubKey, error) {
 		if extensionIDEqual(ext.Id, extensionID) {
 			keyExt = ext
 			found = true
+			for i, oident := range cert.UnhandledCriticalExtensions {
+				if oident.Equal(ext.Id) {
+					// delete the extension from UnhandledCriticalExtensions
+					cert.UnhandledCriticalExtensions = append(cert.UnhandledCriticalExtensions[:i], cert.UnhandledCriticalExtensions[i+1:]...)
+					break
+				}
+			}
 			break
 		}
 	}
 	if !found {
 		return nil, errors.New("expected certificate to contain the key extension")
 	}
+	if _, err := cert.Verify(x509.VerifyOptions{Roots: pool}); err != nil {
+		// If we return an x509 error here, it will be sent on the wire.
+		// Wrap the error to avoid that.
+		return nil, fmt.Errorf("certificate verification failed: %s", err)
+	}
+
 	var sk signedKey
 	if _, err := asn1.Unmarshal(keyExt.Value, &sk); err != nil {
 		return nil, fmt.Errorf("unmarshalling signed certificate failed: %s", err)
@@ -190,7 +198,7 @@ func keyToCertificate(sk ic.PrivKey) (*tls.Certificate, error) {
 		NotAfter:     time.Now().Add(certValidityPeriod),
 		// after calling CreateCertificate, these will end up in Certificate.Extensions
 		ExtraExtensions: []pkix.Extension{
-			{Id: extensionID, Value: value},
+			{Id: extensionID, Critical: extensionCritical, Value: value},
 		},
 	}
 	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, certKey.Public(), certKey)


### PR DESCRIPTION
Fixes #87.