### PR TITLE
Export methods to allow generating custom certificates

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -1,6 +1,7 @@
 package libp2ptls
 
 import (
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
@@ -38,7 +39,12 @@ type Identity struct {
 
 // NewIdentity creates a new identity
 func NewIdentity(privKey ic.PrivKey) (*Identity, error) {
-	cert, err := keyToCertificate(privKey)
+	certTmpl, err := defaultCertTemplate()
+	if err != nil {
+		return nil, err
+	}
+
+	cert, err := KeyToCertificate(privKey, certTmpl)
 	if err != nil {
 		return nil, err
 	}
@@ -157,17 +163,15 @@ func PubKeyFromCertChain(chain []*x509.Certificate) (ic.PubKey, error) {
 	return pubKey, nil
 }
 
-func keyToCertificate(sk ic.PrivKey) (*tls.Certificate, error) {
-	certKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		return nil, err
-	}
-
+// GenerateSignedExtension uses the provided private key to sign the public key, and returns the
+// signature within a pkix.Extension.
+// This extension is included in a certificate to cryptographically tie it to the libp2p private key.
+func GenerateSignedExtension(sk ic.PrivKey, pubKey crypto.PublicKey) (*pkix.Extension, error) {
 	keyBytes, err := ic.MarshalPublicKey(sk.GetPublic())
 	if err != nil {
 		return nil, err
 	}
-	certKeyPub, err := x509.MarshalPKIXPublicKey(certKey.Public())
+	certKeyPub, err := x509.MarshalPKIXPublicKey(pubKey)
 	if err != nil {
 		return nil, err
 	}
@@ -183,28 +187,26 @@ func keyToCertificate(sk ic.PrivKey) (*tls.Certificate, error) {
 		return nil, err
 	}
 
-	bigNum := big.NewInt(1 << 62)
-	sn, err := rand.Int(rand.Reader, bigNum)
+	return &pkix.Extension{Id: extensionID, Critical: extensionCritical, Value: value}, nil
+}
+
+// KeyToCertificate generates a new ECDSA private key and corresponding x509 certificate.
+// The certificate includes an extension that cryptographically ties it to the provided libp2p
+// private key to authenticate TLS connections.
+func KeyToCertificate(sk ic.PrivKey, certTmpl *x509.Certificate) (*tls.Certificate, error) {
+	certKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return nil, err
 	}
-	subjectSN, err := rand.Int(rand.Reader, bigNum)
+
+	// after calling CreateCertificate, these will end up in Certificate.Extensions
+	extension, err := GenerateSignedExtension(sk, certKey.Public())
 	if err != nil {
 		return nil, err
 	}
-	tmpl := &x509.Certificate{
-		SerialNumber: sn,
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(certValidityPeriod),
-		// According to RFC 3280, the issuer field must be set,
-		// see https://datatracker.ietf.org/doc/html/rfc3280#section-4.1.2.4.
-		Subject: pkix.Name{SerialNumber: subjectSN.String()},
-		// after calling CreateCertificate, these will end up in Certificate.Extensions
-		ExtraExtensions: []pkix.Extension{
-			{Id: extensionID, Critical: extensionCritical, Value: value},
-		},
-	}
-	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, certKey.Public(), certKey)
+	certTmpl.ExtraExtensions = append(certTmpl.ExtraExtensions, *extension)
+
+	certDER, err := x509.CreateCertificate(rand.Reader, certTmpl, certTmpl, certKey.Public(), certKey)
 	if err != nil {
 		return nil, err
 	}
@@ -214,12 +216,34 @@ func keyToCertificate(sk ic.PrivKey) (*tls.Certificate, error) {
 	}, nil
 }
 
+func defaultCertTemplate() (*x509.Certificate, error) {
+	bigNum := big.NewInt(1 << 62)
+	sn, err := rand.Int(rand.Reader, bigNum)
+	if err != nil {
+		return nil, err
+	}
+
+	subjectSN, err := rand.Int(rand.Reader, bigNum)
+	if err != nil {
+		return nil, err
+	}
+
+	return &x509.Certificate{
+		SerialNumber: sn,
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(certValidityPeriod),
+		// According to RFC 3280, the issuer field must be set,
+		// see https://datatracker.ietf.org/doc/html/rfc3280#section-4.1.2.4.
+		Subject: pkix.Name{SerialNumber: subjectSN.String()},
+	}, nil
+}
+
 // We want nodes without AES hardware (e.g. ARM) support to always use ChaCha.
 // Only if both nodes have AES hardware support (e.g. x86), AES should be used.
 // x86->x86: AES, ARM->x86: ChaCha, x86->ARM: ChaCha and ARM->ARM: Chacha
 // This function returns true if we don't have AES hardware support, and false otherwise.
 // Thus, ARM servers will always use their own cipher suite preferences (ChaCha first),
-// and x86 servers will aways use the client's cipher suite preferences.
+// and x86 servers will always use the client's cipher suite preferences.
 func preferServerCipherSuites() bool {
 	// Copied from the Go TLS implementation.
 

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -1,0 +1,48 @@
+package libp2ptls
+
+import (
+	"crypto/x509"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewIdentityCertificates(t *testing.T) {
+	_, key := createPeer(t)
+	cn := "a.test.name"
+	email := "unittest@example.com"
+
+	t.Run("NewIdentity with default template", func(t *testing.T) {
+		// Generate an identity using the default template
+		id, err := NewIdentity(key)
+		assert.NoError(t, err)
+
+		// Extract the x509 certificate
+		x509Cert, err := x509.ParseCertificate(id.config.Certificates[0].Certificate[0])
+		assert.NoError(t, err)
+
+		// verify the common name and email are not set
+		assert.Empty(t, x509Cert.Subject.CommonName)
+		assert.Empty(t, x509Cert.EmailAddresses)
+	})
+
+	t.Run("NewIdentity with custom template", func(t *testing.T) {
+		tmpl, err := DefaultCertTemplate()
+		assert.NoError(t, err)
+
+		tmpl.Subject.CommonName = cn
+		tmpl.EmailAddresses = []string{email}
+
+		// Generate an identity using the custom template
+		id, err := NewIdentity(key, WithCertTemplate(tmpl))
+		assert.NoError(t, err)
+
+		// Extract the x509 certificate
+		x509Cert, err := x509.ParseCertificate(id.config.Certificates[0].Certificate[0])
+		assert.NoError(t, err)
+
+		// verify the common name and email are set
+		assert.Equal(t, cn, x509Cert.Subject.CommonName)
+		assert.Equal(t, email, x509Cert.EmailAddresses[0])
+	})
+}


### PR DESCRIPTION
Closes: https://github.com/libp2p/go-libp2p/issues/1538

This PR refactors `keyToCertificate` into 3 methods
* `DefaultCertTemplate` (exported), which returns the default certificate template used to generate the self-signed certificate,
* `generateSignedExtension`, which generates the signed extension
* `keyToCertificate`, which accepts an `x509.Certificate` template, adds the signed extension and returns the `tls.Certificate` object.

This PR also adds a new optional parameter to `NewIdentity`, which can provide a custom certificate template.

The changes are intended to be backwards compatible and add the ability for a caller to specify the x509 certificate fields they wish to include in the generated certificate.