### PR TITLE
Remove x/sys/cpu reference when building for js

### DIFF
--- a/cpu.go
+++ b/cpu.go
@@ -1,0 +1,19 @@
+//go:build !js
+// +build !js
+
+package libp2ptls
+
+import (
+	"golang.org/x/sys/cpu"
+)
+
+// Check the cpu flags for each platform that has optimized GCM implementations.
+// Worst case, these variables will just all be false.
+var (
+	hasGCMAsmAMD64 = cpu.X86.HasAES && cpu.X86.HasPCLMULQDQ
+	hasGCMAsmARM64 = cpu.ARM64.HasAES && cpu.ARM64.HasPMULL
+	// Keep in sync with crypto/aes/cipher_s390x.go.
+	hasGCMAsmS390X = cpu.S390X.HasAES && cpu.S390X.HasAESCBC && cpu.S390X.HasAESCTR && (cpu.S390X.HasGHASH || cpu.S390X.HasAESGCM)
+
+	hasGCMAsm = hasGCMAsmAMD64 || hasGCMAsmARM64 || hasGCMAsmS390X
+)

--- a/cpu_other.go
+++ b/cpu_other.go
@@ -1,0 +1,13 @@
+//go:build js
+// +build js
+
+package libp2ptls
+
+// JS does not support hardware accelerated CPU instructions for crypto.
+var (
+	hasGCMAsmAMD64 = false // cpu.X86.HasAES && cpu.X86.HasPCLMULQDQ
+	hasGCMAsmARM64 = false // cpu.ARM64.HasAES && cpu.ARM64.HasPMULL
+	hasGCMAsmS390X = false // cpu.S390X.HasAES && cpu.S390X.HasAESCBC && cpu.S390X.HasAESCTR && (cpu.S390X.HasGHASH || cpu.S390X.HasAESGCM)
+
+	hasGCMAsm = false // hasGCMAsmAMD64 || hasGCMAsmARM64 || hasGCMAsmS390X
+)

--- a/crypto.go
+++ b/crypto.go
@@ -13,8 +13,6 @@ import (
 	"math/big"
 	"time"
 
-	"golang.org/x/sys/cpu"
-
 	ic "github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
 )
@@ -222,16 +220,5 @@ func keyToCertificate(sk ic.PrivKey) (*tls.Certificate, error) {
 // and x86 servers will aways use the client's cipher suite preferences.
 func preferServerCipherSuites() bool {
 	// Copied from the Go TLS implementation.
-
-	// Check the cpu flags for each platform that has optimized GCM implementations.
-	// Worst case, these variables will just all be false.
-	var (
-		hasGCMAsmAMD64 = cpu.X86.HasAES && cpu.X86.HasPCLMULQDQ
-		hasGCMAsmARM64 = cpu.ARM64.HasAES && cpu.ARM64.HasPMULL
-		// Keep in sync with crypto/aes/cipher_s390x.go.
-		hasGCMAsmS390X = cpu.S390X.HasAES && cpu.S390X.HasAESCBC && cpu.S390X.HasAESCTR && (cpu.S390X.HasGHASH || cpu.S390X.HasAESGCM)
-
-		hasGCMAsm = hasGCMAsmAMD64 || hasGCMAsmARM64 || hasGCMAsmS390X
-	)
 	return !hasGCMAsm
 }


### PR DESCRIPTION
Fixes the build with "gopherjs build -v"